### PR TITLE
Add two wunderground stations

### DIFF
--- a/providers/wunderground.py
+++ b/providers/wunderground.py
@@ -13,7 +13,7 @@ class WUnderground(Provider):
         self.log.info("Processing WUnderground data...")
         try:
             # TODO move station list to admin_db?
-            wu_station_ids = ["INZIDE9"]
+            wu_station_ids = ["INZIDE9", "ISOGND5", "IHAFSL5"]
 
             for wu_station_id in wu_station_ids:
                 url = (


### PR DESCRIPTION
If you want some real world testing on the wunderground integration, you can add these two stations. They are both validated and our main flying wind gauges for our area. Just making a quick pr if you want it super easy to merge ;)

I have checked that the url responds with the given parameters, but not build the whole project.

https://github.com/winds-mobi/winds-mobi-providers/issues/129#issuecomment-2955741053